### PR TITLE
Added TestServerStartup and some underlying providers.

### DIFF
--- a/src/ForEvolve.XUnit/ForEvolve.XUnit.csproj
+++ b/src/ForEvolve.XUnit/ForEvolve.XUnit.csproj
@@ -33,4 +33,8 @@
     <Folder Include="Identity\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\ForEvolve.AspNetCore\ForEvolve.AspNetCore.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/ForEvolve.XUnit/HttpTests/IResponseProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/IResponseProvider.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public interface IResponseProvider
+    {
+        string ResponseText(HttpContext context);
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/IStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/IStatusCodeProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public interface IStatusCodeProvider
+    {
+        int StatusCode { get; }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/ResponseProviders/DelegateResponseProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/ResponseProviders/DelegateResponseProvider.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class DelegateResponseProvider : IResponseProvider
+    {
+        private readonly Func<HttpContext, string> _responseTextDelegate;
+        public DelegateResponseProvider(Func<HttpContext, string> responseTextDelegate)
+        {
+            _responseTextDelegate = responseTextDelegate ?? throw new ArgumentNullException(nameof(responseTextDelegate));
+        }
+
+        public string ResponseText(HttpContext context)
+        {
+            return _responseTextDelegate(context);
+        }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/ResponseProviders/DynamicInternalServerErrorResponseProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/ResponseProviders/DynamicInternalServerErrorResponseProvider.cs
@@ -1,0 +1,34 @@
+﻿using ForEvolve.Api.Contracts.Errors;
+using ForEvolve.AspNetCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class DynamicInternalServerErrorResponseProvider : DelegateResponseProvider
+    {
+        public DynamicInternalServerErrorResponseProvider(Func<IErrorFactory, Error> createErrorDelegate)
+            : base(context =>
+            {
+                var errorFactory = context.RequestServices.GetRequiredService<IErrorFactory>();
+                var error = createErrorDelegate(errorFactory);
+
+                var result = new ErrorResponse(error);
+                return JsonConvert.SerializeObject(result);
+            })
+        { }
+
+        public DynamicInternalServerErrorResponseProvider(Error error)
+            : base(context =>
+            {
+                var result = new ErrorResponse(error);
+                return JsonConvert.SerializeObject(result);
+            })
+        { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/ResponseProviders/EchoResponseProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/ResponseProviders/EchoResponseProvider.cs
@@ -1,0 +1,47 @@
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class EchoResponseProvider : IResponseProvider
+    {
+        public string ResponseText(HttpContext context)
+        {
+            var request = JsonConvert.SerializeObject(
+                context.Request,
+                new JsonSerializerSettings
+                {
+                    ContractResolver = new HttpRequestContractResolver()
+                }
+            );
+            return request;
+        }
+
+        private class HttpRequestContractResolver : DefaultContractResolver
+        {
+            public IEnumerable<string> ExcludedProperties { get; }
+            public HttpRequestContractResolver()
+            {
+                ExcludedProperties = new string[]{
+                    nameof(HttpRequest.Body),
+                    nameof(HttpRequest.HttpContext),
+                    nameof(HttpRequest.Form),
+                };
+            }
+
+            protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+            {
+                return base
+                    .CreateProperties(type, memberSerialization)
+                    .Where(p => !ExcludedProperties.Contains(p.PropertyName))
+                    .ToList();
+            }
+        }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/ResponseProviders/JsonPathResponseProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/ResponseProviders/JsonPathResponseProvider.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using System;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class JsonPathResponseProvider : IResponseProvider
+    {
+        private readonly object _successObject;
+        private readonly object _failureObject;
+        private readonly string _expectedPath;
+        private readonly string _expectedMethod;
+
+        public JsonPathResponseProvider(string expectedMethod, string expectedPath, object successObject, object failureObject)
+        {
+            _expectedPath = expectedPath ?? throw new ArgumentNullException(nameof(expectedPath));
+            _expectedMethod = expectedMethod ?? throw new ArgumentNullException(nameof(expectedMethod));
+            _successObject = successObject ?? throw new ArgumentNullException(nameof(successObject));
+            _failureObject = failureObject ?? throw new ArgumentNullException(nameof(failureObject));
+        }
+
+        public string ResponseText(HttpContext context)
+        {
+            if (context.Request.Path.Value == _expectedPath)
+            {
+                if (context.Request.Method == _expectedMethod)
+                {
+                    return JsonConvert.SerializeObject(_successObject);
+                }
+            }
+            return JsonConvert.SerializeObject(_failureObject);
+        }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/BadRequestStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/BadRequestStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class BadRequestStatusCodeProvider : StatusCodeProvider
+    {
+        public BadRequestStatusCodeProvider() : base(StatusCodes.Status400BadRequest) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/CreatedStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/CreatedStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class CreatedStatusCodeProvider : StatusCodeProvider
+    {
+        public CreatedStatusCodeProvider() : base(StatusCodes.Status201Created) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/ForbiddenStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/ForbiddenStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class ForbiddenStatusCodeProvider : StatusCodeProvider
+    {
+        public ForbiddenStatusCodeProvider() : base(StatusCodes.Status403Forbidden) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/InternalServerErrorStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/InternalServerErrorStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class InternalServerErrorStatusCodeProvider : StatusCodeProvider
+    {
+        public InternalServerErrorStatusCodeProvider() : base(StatusCodes.Status500InternalServerError) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/NotFoundStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/NotFoundStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class NotFoundStatusCodeProvider : StatusCodeProvider
+    {
+        public NotFoundStatusCodeProvider() : base(StatusCodes.Status404NotFound) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/OkStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/OkStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class OkStatusCodeProvider : StatusCodeProvider
+    {
+        public OkStatusCodeProvider() : base(StatusCodes.Status200OK) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/StatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/StatusCodeProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace ForEvolve.XUnit.HttpTests
+{
+    public class StatusCodeProvider : IStatusCodeProvider
+    {
+        public StatusCodeProvider(int statusCode)
+        {
+            StatusCode = statusCode;
+        }
+        public int StatusCode { get; }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/UnauthorizedStatusCodeProvider.cs
+++ b/src/ForEvolve.XUnit/HttpTests/StatusCodeProviders/UnauthorizedStatusCodeProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public sealed class UnauthorizedStatusCodeProvider : StatusCodeProvider
+    {
+        public UnauthorizedStatusCodeProvider() : base(StatusCodes.Status401Unauthorized) { }
+    }
+}

--- a/src/ForEvolve.XUnit/HttpTests/TestServerStartup.cs
+++ b/src/ForEvolve.XUnit/HttpTests/TestServerStartup.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class TestServerStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.TryAddSingleton<IStatusCodeProvider, OkStatusCodeProvider>();
+            services.TryAddSingleton<IResponseProvider, EchoResponseProvider>();
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.Run(context =>
+            {
+                // Get services
+                var statusCodeProvider = app.ApplicationServices.GetRequiredService<IStatusCodeProvider>();
+                var responseProvider = app.ApplicationServices.GetRequiredService<IResponseProvider>();
+
+                // Set response 
+                context.Response.StatusCode = statusCodeProvider.StatusCode;
+                var responseText = responseProvider.ResponseText(context);
+                return responseText == null ? Task.CompletedTask : context.Response.WriteAsync(responseText);
+            });
+        }
+    }
+}

--- a/test/ForEvolve.XUnit.Tests/HttpTests/JsonPathResponseProviderTest.cs
+++ b/test/ForEvolve.XUnit.Tests/HttpTests/JsonPathResponseProviderTest.cs
@@ -1,0 +1,96 @@
+﻿using ForEvolve.XUnit.Http;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ForEvolve.XUnit.HttpTests
+{
+    public class JsonPathResponseProviderTest
+    {
+        private readonly JsonPathResponseProvider _providerUnderTest;
+
+        private readonly string _expectedMethod;
+        private readonly string _expectedPath;
+        private readonly JsonPathResponseObject _successObject;
+        private readonly JsonPathResponseObject _failureObject;
+
+        private readonly string _expectedSuccessResponseText;
+        private readonly string _expectedFailureResponseText;
+
+        private readonly HttpContextHelper _httpContextHelper;
+
+        public JsonPathResponseProviderTest()
+        {
+            _httpContextHelper = new HttpContextHelper();
+
+            _expectedMethod = "POST";
+            _expectedPath = "/whatever";
+            _successObject = new JsonPathResponseObject { IsSuccess = true };
+            _failureObject = new JsonPathResponseObject { IsSuccess = false };
+
+            _expectedSuccessResponseText = JsonConvert.SerializeObject(_successObject);
+            _expectedFailureResponseText = JsonConvert.SerializeObject(_failureObject);
+
+            _providerUnderTest = new JsonPathResponseProvider(
+                _expectedMethod,
+                _expectedPath,
+                _successObject,
+                _failureObject
+            );
+        }
+
+        public class JsonPathResponseObject
+        {
+            public bool IsSuccess { get; set; }
+        }
+
+        public class ResponseText : JsonPathResponseProviderTest
+        {
+            [Fact]
+            public void Should_return_failure_if_Method_is_incorrect()
+            {
+                // Arrange
+                _httpContextHelper.HttpRequest.Method = "GET";
+                _httpContextHelper.HttpRequest.Path = _expectedPath;
+
+                // Act
+                var result = _providerUnderTest.ResponseText(_httpContextHelper.HttpContextMock.Object);
+
+                // Assert
+                Assert.Equal(_expectedFailureResponseText, result);
+            }
+
+            [Fact]
+            public void Should_return_failure_if_Path_is_incorrect()
+            {
+                // Arrange
+                _httpContextHelper.HttpRequest.Method = _expectedMethod;
+                _httpContextHelper.HttpRequest.Path = "/some/other/path";
+
+                // Act
+                var result = _providerUnderTest.ResponseText(_httpContextHelper.HttpContextMock.Object);
+
+                // Assert
+                Assert.Equal(_expectedFailureResponseText, result);
+            }
+
+            [Fact]
+            public void Should_return_success_if_Path_and_Method_are_correct()
+            {
+                // Arrange
+                _httpContextHelper.HttpRequest.Method = _expectedMethod;
+                _httpContextHelper.HttpRequest.Path = _expectedPath;
+
+                // Act
+                var result = _providerUnderTest.ResponseText(_httpContextHelper.HttpContextMock.Object);
+
+                // Assert
+                Assert.Equal(_expectedSuccessResponseText, result);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added ResponseProviders and the following providers Delegate, DynamicInternalServerError, Echo, and JsonPath.
- Added StatusCodeProvider and several other standard status code providers like OK, NotFound, etc.
- Updated BaseHttpTestTest to use these new classes.

All of these will help test HTTP related elements like Web APIs, middlewares, etc.