### PR TITLE
BaseHttpTest now create and dispose a request scope.

### DIFF
--- a/src/ForEvolve.XUnit/HttpTests/BaseHttpTest.cs
+++ b/src/ForEvolve.XUnit/HttpTests/BaseHttpTest.cs
@@ -53,7 +53,8 @@ namespace ForEvolve.XUnit.HttpTests
 
         private readonly IHttpTestServer _httpTestServer;
 
-        protected IServiceProvider Services => Server.Host.Services;
+        public IServiceProvider Services => RequestScope.ServiceProvider;
+        protected IServiceScope RequestScope { get; }
 
         public BaseHttpTest()
             : this(WebHost.CreateDefaultBuilder())
@@ -71,6 +72,9 @@ namespace ForEvolve.XUnit.HttpTests
                 ;
             builder = ConfigureWebHostBuilder(builder);
             _httpTestServer = new HttpTestServerBuilder().Create(() => builder);
+
+            // Create a request scope
+            RequestScope = Server.Host.Services.CreateScope();
         }
 
         protected virtual void ConfigureServices(IServiceCollection services)
@@ -92,6 +96,7 @@ namespace ForEvolve.XUnit.HttpTests
             {
                 if (disposing)
                 {
+                    RequestScope.Dispose();
                     _httpTestServer.Dispose();
                 }
                 _isDisposed = true;

--- a/test/ForEvolve.XUnit.Tests/HttpTests/BaseHttpTestTest.cs
+++ b/test/ForEvolve.XUnit.Tests/HttpTests/BaseHttpTestTest.cs
@@ -52,5 +52,84 @@ namespace ForEvolve.XUnit.HttpTests
             }
         }
 
+
+        public class RequestScopeTest
+        {
+            [Fact]
+            public void Services_should_return_the_same_singleton_object_everytime()
+            {
+                using (var sut = new MyHttpTest())
+                {
+                    var singleton1 = sut.Services.GetService<ISingletonDep>();
+                    var singleton2 = sut.Services.GetService<ISingletonDep>();
+                    Assert.Same(singleton1, singleton2);
+
+                    using (var subScope = sut.Services.CreateScope())
+                    {
+                        var singleton3 = subScope.ServiceProvider.GetService<ISingletonDep>();
+                        Assert.Same(singleton2, singleton3);
+                    }
+                }
+            }
+
+            [Fact]
+            public void Services_should_return_the_same_scoped_object_in_the_current_scope()
+            {
+                using (var sut = new MyHttpTest())
+                {
+                    var scoped1 = sut.Services.GetService<IScopedDep>();
+                    var scoped2 = sut.Services.GetService<IScopedDep>();
+                    Assert.Same(scoped1, scoped2);
+
+                    using (var subScope = sut.Services.CreateScope())
+                    {
+                        var scoped3 = subScope.ServiceProvider.GetService<IScopedDep>();
+                        Assert.NotSame(scoped2, scoped3);
+                    }
+                }
+            }
+
+            [Fact]
+            public void Services_should_always_return_a_different_transient_object_no_matter_the_scope()
+            {
+                using (var sut = new MyHttpTest())
+                {
+                    var transient1 = sut.Services.GetService<ITransientDep>();
+                    var transient2 = sut.Services.GetService<ITransientDep>();
+                    Assert.NotSame(transient1, transient2);
+
+                    using (var subScope = sut.Services.CreateScope())
+                    {
+                        var transient3 = subScope.ServiceProvider.GetService<ITransientDep>();
+                        Assert.NotSame(transient2, transient3);
+                    }
+                }
+            }
+
+            private interface ISingletonDep { }
+            private interface IScopedDep { }
+            private interface ITransientDep { }
+
+            private class MyDependency : ISingletonDep, IScopedDep, ITransientDep { }
+
+            private class MyHttpTest : BaseHttpTest
+            {
+                protected override IWebHostBuilder ConfigureWebHostBuilder(IWebHostBuilder webHostBuilder)
+                {
+                    webHostBuilder
+                        .ConfigureServices(services =>
+                        {
+                            services
+                                .AddSingleton<ISingletonDep, MyDependency>()
+                                .AddScoped<IScopedDep, MyDependency>()
+                                .AddTransient<ITransientDep, MyDependency>()
+                                ;
+                        })
+                        .Configure(app => { })
+                        ;
+                    return webHostBuilder;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
`BaseHttpTest` now create and dispose a request scope.
> The scope is bound to the lifetime of the `BaseHttpTest` instance; simulating an HTTP request scope.

`BaseHttpTest` now expose a `Services` property.
> The `Services` property is bound to `RequestScope.ServiceProvider`