### PR TITLE
Moved ServiceCollectionExtensions from feature/base-http-test-server

### DIFF
--- a/src/ForEvolve.XUnit/Microsoft.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/ForEvolve.XUnit/Microsoft.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection RemoveFilter<TFilter>(this IServiceCollection services) 
+            where TFilter : IFilterMetadata
+        {
+            return services.PostConfigure<MvcOptions>(options =>
+            {
+                var filters = options.Filters.Where(x => x.GetType() == typeof(RequireHttpsAttribute)).ToArray();
+                if(filters != null && filters.Count() > 0)
+                {
+                    foreach (var filter in filters)
+                    {
+                        options.Filters.Remove(filter);
+                    }
+                }
+            });
+        }
+
+        public static IServiceCollection ByPassPolicies(this IServiceCollection services, IEnumerable<string> policiesName)
+        {
+            var authorizedPolicy = CreateAuthorizedPolicy();
+            return services.PostConfigure<AuthorizationOptions>(options =>
+            {
+                foreach (var policyName in policiesName)
+                {
+                    options.AddPolicy(policyName, authorizedPolicy);
+                }
+                options.DefaultPolicy = authorizedPolicy;
+            });
+        }
+
+        public static IServiceCollection ByPassDefaultPolicy(this IServiceCollection services)
+        {
+            var authorizedPolicy = CreateAuthorizedPolicy();
+            return services.PostConfigure<AuthorizationOptions>(options =>
+            {
+                options.DefaultPolicy = authorizedPolicy;
+            });
+        }
+
+        public static IServiceCollection ReplacePolicy(this IServiceCollection services, string policyName, AuthorizationPolicy policy)
+        {
+            return services.PostConfigure<AuthorizationOptions>(options =>
+            {
+                options.AddPolicy(policyName, policy);
+            });
+        }
+
+        private static AuthorizationPolicy CreateAuthorizedPolicy()
+        {
+            return new AuthorizationPolicyBuilder()
+                .RequireAssertion(x => true)
+                .Build();
+        }
+    }
+}


### PR DESCRIPTION
Adds a few `IServiceCollection` extension methods that are useful for testing policy based MVC applications. The `RemoveFilter<TFilter>()` method can be used to remove `RequireHttpsAttribute` for example.

- `RemoveFilter<TFilter>()` remove all `IFilterMetadata` of type `TFilter` from `MvcOptions`
- `ByPassPolicies(policiesName)` allow requests to pass through the specified policies.
- `ByPassDefaultPolicy()` set the `AuthorizationOptions.DefaultPolicy` to the "bypass policy".
- `ReplacePolicy(policyName, policy)` "replace" the specified policy by the new one.