### PR TITLE
Removed DisableHtml from MarkdigOptions

### DIFF
--- a/src/ForEvolve.Markdown/Markdig/MarkdigOptions.cs
+++ b/src/ForEvolve.Markdown/Markdig/MarkdigOptions.cs
@@ -5,7 +5,6 @@ namespace ForEvolve.Markdown
 {
     public class MarkdigOptions
     {
-        public bool DisableHtml { get; set; } = true;
         public Action<MarkdownPipelineBuilder> Configure { get; set; }
     }
 }

--- a/src/ForEvolve.Markdown/Markdig/MarkdigStartupExtensions.cs
+++ b/src/ForEvolve.Markdown/Markdig/MarkdigStartupExtensions.cs
@@ -25,10 +25,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(provider => {
                 // Customize the pipeline
                 var builder = new MarkdownPipelineBuilder();
-                if(options.DisableHtml)
-                {
-                    builder.DisableHtml();
-                }
                 options.Configure?.Invoke(builder);
                 return builder.Build();
             });

--- a/test/ForEvolve.Markdown.Tests/MarkdownStartupExtensionsTest.cs
+++ b/test/ForEvolve.Markdown.Tests/MarkdownStartupExtensionsTest.cs
@@ -27,49 +27,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
-        public void Should_disable_html_by_default()
-        {
-            // Arrange
-            var services = new ServiceCollection();
-
-            // Act & Assert
-            services.AddMarkdig(options =>
-            {
-                options.Configure = builder =>
-                {
-                    var parser = builder.BlockParsers.Find<HtmlBlockParser>();
-                    Assert.Null(parser);
-
-                    var inlineParser = builder.InlineParsers.Find<AutolineInlineParser>();
-                    Assert.False(inlineParser.EnableHtmlParsing);
-                };
-            });
-            AssertMarkdownConverter(services);
-        }
-
-        [Fact]
-        public void Should_not_disable_html_when_specified_in_options()
-        {
-            // Arrange
-            var services = new ServiceCollection();
-
-            // Act & Assert
-            services.AddMarkdig(options =>
-            {
-                options.DisableHtml = false;
-                options.Configure = builder =>
-                {
-                    var parser = builder.BlockParsers.Find<HtmlBlockParser>();
-                    Assert.NotNull(parser);
-
-                    var inlineParser = builder.InlineParsers.Find<AutolineInlineParser>();
-                    Assert.True(inlineParser.EnableHtmlParsing);
-                };
-            });
-            AssertMarkdownConverter(services);
-        }
-
-        [Fact]
         public void Should_configure_pipeline_when_an_action_is_provided()
         {
             // Arrange


### PR DESCRIPTION
`MarkdigStartupExtensions.AddMarkdig()` does not disable HTML by default anymore.
To disable HTML, use `MarkdigOptions.Configure`.
See #19